### PR TITLE
fix wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We organize the papers by [research areas](#paper-by-research-area) for challeng
 ## Paper (By conference and journal)
 
 - [Federated learning paper by conferences](conferences.md): NeurIPS, ICML, ICLR, CVPR, ICCV, AAAI, IJCAI, ACMMM, etc.
-- [Federated learning paper by journal](journal.md)
+- [Federated learning paper by journal](journals.md)
 
 ## Paper (By research area)
 


### PR DESCRIPTION
Fix the wrong link for "Federated learning paper by journal" in README.md.